### PR TITLE
Correction to install PHP 8 modules only.

### DIFF
--- a/docker/files/damp.df
+++ b/docker/files/damp.df
@@ -45,14 +45,13 @@ RUN echo 'deb https://packages.sury.org/php/ buster main' > /etc/apt/sources.lis
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        php-xdebug \
-        php-uploadprogress \
-        php-apcu \
+        php8.0-apcu \
         php8.0-curl \
         php8.0-gd \
         php8.0-mbstring \
         php8.0-mysql \
         php8.0-sqlite3 \
+        php8.0-xdebug \
         php8.0-xml \
         php8.0-xsl \
         php8.0-zip \


### PR DESCRIPTION
Module php8.0-uploadprogress is missing, for now.